### PR TITLE
Fixed "Call to undefined method Attribute::getAttributeTypes()" in CA 2.0

### DIFF
--- a/plugins/lhmMMS/controllers/AdminToolsController.php
+++ b/plugins/lhmMMS/controllers/AdminToolsController.php
@@ -85,7 +85,7 @@ class AdminToolsController extends ActionController {
 		}
 
 		$this->getView()->setVar('element_list', $va_elements_for_list);
-		$this->getView()->setVar('attribute_types', Attribute::getAttributeTypes());
+		$this->getView()->setVar('attribute_types', CA\Attributes\Attribute::getAttributeTypes());
 
 		$this->render('elements_list_html.php');
 	}


### PR DESCRIPTION
@collectiveaccess 
This pull request aims at solving an issue with one of the LHM-plugins and Collective Access 2.0.