### PR TITLE
[KULTMMS-1386]- Old insurance values are not automatically transferre…

### DIFF
--- a/plugins/lhmMMS/conf/lhmMMS.conf
+++ b/plugins/lhmMMS/conf/lhmMMS.conf
@@ -16,16 +16,20 @@ enabled = 1
 # -------------------------------------------------------------
 
 lhm_mms_hook_registry = {
-	hookAddRelationship = {
-		MMSStorageLocationManagement::manageHistory,
-		MMSCollectionManagement::enforceSingleCollection,
-	},
-#	hookAfterBundleInsert = {
-#		MMSCollectionManagement::setCollectionAndACLsForNewObject
-#	},
-	hookSaveItem = {
-		MMSInsuranceFeatures::calcLoanInsuranceVal
-	},
+    hookAddRelationship = {
+        MMSStorageLocationManagement::manageHistory,
+        MMSCollectionManagement::enforceSingleCollection,
+    },
+    #	hookAfterBundleInsert = {
+    #		MMSCollectionManagement::setCollectionAndACLsForNewObject
+    #	},
+    hookBeforeSaveItem = {
+        MMSInsuranceFeatures::rememberOldInsuranceValue
+    },
+    hookSaveItem = {
+        MMSInsuranceFeatures::calcLoanInsuranceVal,
+        MMSInsuranceFeatures::handleInsuranceValueHistoryOnUpdate
+    },
 }
 
 # -------------------------------------------------------------

--- a/plugins/lhmMMS/lhmMMSPlugin.php
+++ b/plugins/lhmMMS/lhmMMSPlugin.php
@@ -51,6 +51,7 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 	public function hookAfterBundleInsert(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
 	public function hookSaveItem(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
 	public function hookBeforeMoveRelationships(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
+	public function hookBeforeSaveItem(&$pa_params) {$this->reroute(__FUNCTION__, $pa_params);}
 	# -------------------------------------------------------
 	private function reroute($ps_hook_name,&$pa_params) {
 		if(isset($this->opa_hook_registry[$ps_hook_name]) && is_array($this->opa_hook_registry[$ps_hook_name])){

--- a/plugins/lhmMMS/lib/MMSInsuranceFeatures.php
+++ b/plugins/lhmMMS/lib/MMSInsuranceFeatures.php
@@ -8,16 +8,98 @@
  * ----------------------------------------------------------------------
  */
 
-class MMSInsuranceFeatures {
+class MMSInsuranceFeatures
+{
+
+	private static $oldInsuranceVals = [];
+
+	/**
+	 * Speichert den aktuellen Versicherungswert vor dem Speichern
+	 *
+	 * @param $pa_params
+	 * @return void
+	 */
+	public static function rememberOldInsuranceValue(&$pa_params)
+	{
+		$po_object = $pa_params['instance'];
+
+		if ($po_object->tableName() !== 'ca_objects') {
+			return;
+		}
+
+		$id = $po_object->getPrimaryKey();
+
+		// Vorherigen Wert als Array speichern
+		self::$oldInsuranceVals[$id] = $po_object->get('insurance_value_current', ['returnAsArray' => true]);
+	}
+
+	/**
+	 * Wird nach dem Speichern aufgerufen, prüft Änderungen und speichert alten Wert historisch
+	 *
+	 * @param $pa_params
+	 * @return void
+	 */
+	public static function handleInsuranceValueHistoryOnUpdate(&$pa_params)
+	{
+		$po_object = $pa_params['instance'];
+
+		if ($po_object->tableName() !== 'ca_objects') {
+			return;
+		}
+
+		$id = $po_object->getPrimaryKey();
+		$oldVals = self::$oldInsuranceVals[$id] ?? null;
+		$newVals = $po_object->get('insurance_value_current', ['returnAsArray' => true]);
+
+
+		// Keine Änderung oder keine alten/neuen Werte → kein Handlungsbedarf
+		if (!$oldVals || !$newVals || json_encode($oldVals) === json_encode($newVals)) {
+			unset(self::$oldInsuranceVals[$id]);
+			return;
+		}
+
+		$historicValues = $po_object->get('insurance_value_historic', ['returnAsArray' => true]);
+		// Prüft, ob 'insurance_value_historic' nur leere Platzhalter enthält (z. B. ';;') und entfernt es in diesem Fall
+		$filtered = array_filter($historicValues, function ($val) {
+			return trim($val) !== '' && trim($val) !== ';;';
+		});
+		if (empty($filtered)) {
+			$po_object->removeAttributes('insurance_value_historic');
+		}
+
+		foreach ($oldVals as $oldVal) {
+			$parts = array_map('trim', explode(';', $oldVal));
+
+			$date_raw = $parts[0] ?? date('Y-m-d');
+			$date_str = date('Y-m-d', strtotime($date_raw));  // gültiges Datum erzeugen
+
+			$value_raw = $parts[1] ?? '';
+			$value_float = mmsExtractFloatFromCurrencyValue($value_raw);
+			$value_currency = mmsFloatToCurrencyValue($value_float);
+
+			$remark = $parts[2] ?? '';
+
+			$historicData = ['historic_date' => $date_str, 'historic_value_eur' => $value_currency, 'historic_remark' => $remark,];
+
+			$po_object->addAttribute($historicData, 'insurance_value_historic');
+		}
+
+		// Änderungen speichern
+		$po_object->update();
+		unset(self::$oldInsuranceVals[$id]);
+	}
+
 
 	/**
 	 * Berechnet bei Änderung eines Objektes oder einer Leihgabe die
 	 * Gesamt-Versicherungssumme für alle betroffenen Leihgaben neu
-	 * 
+	 *
 	 * @param array $pa_params Parameter-Array, das vom Plugin Hook übergeben wird
 	 */
-	public static function calcLoanInsuranceVal(&$pa_params) {
-		switch($pa_params['instance']->tableName()) {
+	public static function calcLoanInsuranceVal(&$pa_params)
+	{
+
+		switch ($pa_params['instance']->tableName()) {
 			// Leihgabe ist neu oder hat sich geändert
 			case 'ca_loans':
 				// berechne Versicherungswert neu
@@ -28,8 +110,8 @@ class MMSInsuranceFeatures {
 				// Hole alle angehängten Leihgaben und berechne Versicherungswerte neu
 				$va_loans = $pa_params['instance']->getRelatedItems('ca_loans');
 				$t_loan = new ca_loans();
-				foreach($va_loans as $vn_loan_id => $va_loan_info){
-					if($t_loan->load($vn_loan_id)){
+				foreach ($va_loans as $vn_loan_id => $va_loan_info) {
+					if ($t_loan->load($vn_loan_id)) {
 						self::setInsuranceValForLoan($t_loan);
 					}
 				}
@@ -41,21 +123,24 @@ class MMSInsuranceFeatures {
 
 	/**
 	 * Hilfsfunktion, die für eine gegebene Leihgabe die Versicherungssumme berechnet und setzt
-	 * 
+	 *
 	 * @param ca_loans $t_loan BaseModel Instanz der betroffenen Leihgabe
 	 */
-	private static function setInsuranceValForLoan(&$t_loan) {
+	private static function setInsuranceValForLoan(&$t_loan)
+	{
 		// Hole alle Objekte
 		$va_objects = $t_loan->getRelatedItems('ca_objects');
 		$t_object = new ca_objects();
 		$vn_insurance_sum = 0;
-		foreach($va_objects as $vn_index => $va_object_info) {
+		foreach ($va_objects as $vn_index => $va_object_info) {
 			// Wie wird summiert? Jedes Objekt kann mehrere Werte haben
 			// Wir nehmen nur den neuesten her. Dieser lässt sich einfach finden, indem man nach PK sortiert
 			$t_object->load($va_object_info['object_id']);
 			$va_values = $t_object->get('ca_objects.insurance_value_current.current_value_eur', ['returnAsArray' => true]);
-			if (!is_array($va_values)) { continue; }
-		
+			if (!is_array($va_values)) {
+				continue;
+			}
+
 			ksort($va_values); // sortiere nach Primärschlüssel der Werte
 			$vs_val = array_pop($va_values); // wir nehmen den neuesten Wert
 
@@ -63,11 +148,10 @@ class MMSInsuranceFeatures {
 		}
 
 		// editiere den existierenden automatisch gesetzten Wert oder lege einen neuen an
-		$t_loan->replaceAttribute(array(
-			'loan_insurance_remark' => mmsGetSettingFromMMSPluginConfig('lhm_mms_loan_insurance_comment'),
-			'loan_insurance_value_eur' => mmsFloatToCurrencyValue($vn_insurance_sum),
-		),'loan_insurance');
+		$t_loan->replaceAttribute(array('loan_insurance_remark' => mmsGetSettingFromMMSPluginConfig('lhm_mms_loan_insurance_comment'), 'loan_insurance_value_eur' => mmsFloatToCurrencyValue($vn_insurance_sum),), 'loan_insurance');
 
 		$t_loan->update();
 	}
+
+
 }


### PR DESCRIPTION
Comment for GitHub Pull Request:

This change implements the missing functionality requested in the ticket and discussed during the meeting with CA on 03.09.2024.

Background:
Previously, when the field insurance_value_current was updated, the historical value was not automatically copied to insurance_value_historic, which was considered a usability gap (as confirmed by user feedback and documented in the ticket).

What this PR does:

Implements a two-step hook mechanism:

rememberOldInsuranceValue stores the current insurance value before saving.

handleInsuranceValueHistoryOnUpdate checks after saving if the value has changed, and if so, transfers the old value into the insurance_value_historic attribute.

Ensures the data is split correctly (date, value, remark) and formatted properly (e.g., locale-aware currency handling).

Automatically creates a history entry only when changes are detected — preventing unnecessary duplicates.

This behavior mirrors the handling of "storage location history" as discussed and should help prevent manual copy-paste errors and data loss during updates.

Please review and approve if the logic meets expectations. Further UI/UX improvements can follow later if needed.