### PR TITLE
KULTMMS-2179: Fix loan insurance recalculation trigger on loan open

### DIFF
--- a/plugins/lhmMMS/conf/lhmMMS.conf
+++ b/plugins/lhmMMS/conf/lhmMMS.conf
@@ -16,19 +16,26 @@ enabled = 1
 # -------------------------------------------------------------
 
 lhm_mms_hook_registry = {
-    hookAddRelationship = {
-        MMSStorageLocationManagement::manageHistory,
-        MMSCollectionManagement::enforceSingleCollection,
+	hookAddRelationship = {
+		MMSStorageLocationManagement::manageHistory,
+		MMSCollectionManagement::enforceSingleCollection,
+	},
+
+	#hookAfterBundleInsert = {
+    #MMSCollectionManagement::setCollectionAndACLsForNewObject
+    #},
+
+	hookBeforeSaveItem = {
+    MMSInsuranceFeatures::rememberOldInsuranceValue
     },
-    #	hookAfterBundleInsert = {
-    #		MMSCollectionManagement::setCollectionAndACLsForNewObject
-    #	},
-    hookBeforeSaveItem = {
-        MMSInsuranceFeatures::rememberOldInsuranceValue
-    },
+
     hookSaveItem = {
-        MMSInsuranceFeatures::calcLoanInsuranceVal,
-        MMSInsuranceFeatures::handleInsuranceValueHistoryOnUpdate
+    MMSInsuranceFeatures::calcLoanInsuranceVal,
+    MMSInsuranceFeatures::handleInsuranceValueHistoryOnUpdate
+    },
+
+    hookEditItem = {
+    MMSInsuranceFeatures::recalcLoanInsuranceOnOpen
     },
 }
 

--- a/plugins/lhmMMS/lhmMMSPlugin.php
+++ b/plugins/lhmMMS/lhmMMSPlugin.php
@@ -8,17 +8,20 @@
  * Copyright 2014 Landeshauptstadt München
  * ----------------------------------------------------------------------
  */
-require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.'lib'.DIRECTORY_SEPARATOR.'mmsHelpers.php');
-require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.'lib'.DIRECTORY_SEPARATOR.'MMSStorageLocationManagement.php');
-require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.'lib'.DIRECTORY_SEPARATOR.'MMSCollectionManagement.php');
-require_once(dirname(__FILE__).DIRECTORY_SEPARATOR.'lib'.DIRECTORY_SEPARATOR.'MMSInsuranceFeatures.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'mmsHelpers.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'MMSStorageLocationManagement.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'MMSCollectionManagement.php');
+require_once(dirname(__FILE__) . DIRECTORY_SEPARATOR . 'lib' . DIRECTORY_SEPARATOR . 'MMSInsuranceFeatures.php');
 
-class lhmMMSPlugin extends BaseApplicationPlugin {
+class lhmMMSPlugin extends BaseApplicationPlugin
+{
 	# -------------------------------------------------------
 	private $opo_datamodel;
 	private $opa_relationships_to_edit = array();
+
 	# -------------------------------------------------------
-	public function __construct($ps_plugin_path) {
+	public function __construct($ps_plugin_path)
+	{
 		$this->description = _t('Zusatzfunktionalität für LHM MMS');
 		parent::__construct();
 
@@ -27,10 +30,12 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 		$this->opo_datamodel = Datamodel::load();
 	}
 	# -------------------------------------------------------
+
 	/**
 	 * Override checkStatus() to return true - the MMS plugin always initializes ok
 	 */
-	public function checkStatus() {
+	public function checkStatus()
+	{
 		return array(
 			'description' => $this->getDescription(),
 			'errors' => array(),
@@ -47,18 +52,45 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 	 * through __call is unfortunately not sufficient.
 	 */
 	# -------------------------------------------------------
-	public function hookAddRelationship(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
-	public function hookAfterBundleInsert(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
-	public function hookSaveItem(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
-	public function hookBeforeMoveRelationships(&$pa_params) { $this->reroute(__FUNCTION__,$pa_params); }
-	public function hookBeforeSaveItem(&$pa_params) {$this->reroute(__FUNCTION__, $pa_params);}
+	public function hookAddRelationship(&$pa_params)
+	{
+		$this->reroute(__FUNCTION__, $pa_params);
+	}
+
+	public function hookAfterBundleInsert(&$pa_params)
+	{
+		$this->reroute(__FUNCTION__, $pa_params);
+	}
+
+	public function hookSaveItem(&$pa_params)
+	{
+		$this->reroute(__FUNCTION__, $pa_params);
+	}
+
+	public function hookBeforeMoveRelationships(&$pa_params)
+	{
+		$this->reroute(__FUNCTION__, $pa_params);
+	}
+
+	public function hookBeforeSaveItem(&$pa_params)
+	{
+		$this->reroute(__FUNCTION__, $pa_params);
+	}
+
+	public function hookEditItem(&$pa_params)
+	{
+		$this->reroute(__FUNCTION__, $pa_params);
+	}
+
+
 	# -------------------------------------------------------
-	private function reroute($ps_hook_name,&$pa_params) {
-		if(isset($this->opa_hook_registry[$ps_hook_name]) && is_array($this->opa_hook_registry[$ps_hook_name])){
-			foreach($this->opa_hook_registry[$ps_hook_name] as $vs_call) {
-				$va_tmp = explode("::", $vs_call);
-				if(sizeof($va_tmp)==2){
-					if(class_exists($va_tmp[0]) && method_exists($va_tmp[0], $va_tmp[1])){
+	private function reroute($ps_hook_name, &$pa_params)
+	{
+		if (isset($this->opa_hook_registry[$ps_hook_name]) && is_array($this->opa_hook_registry[$ps_hook_name])) {
+			foreach ($this->opa_hook_registry[$ps_hook_name] as $vs_call) {
+				$va_tmp = explode('::', $vs_call);
+				if (sizeof($va_tmp) == 2) {
+					if (class_exists($va_tmp[0]) && method_exists($va_tmp[0], $va_tmp[1])) {
 						$va_tmp[0]::{$va_tmp[1]}($pa_params);
 					}
 				}
@@ -66,18 +98,20 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 		}
 	}
 	# -------------------------------------------------------
+
 	/**
 	 * Füge Menü-Item für Scanner Import hinzu
 	 */
-	public function hookRenderMenuBar($pa_menu_bar) {
+	public function hookRenderMenuBar($pa_menu_bar)
+	{
 		if ($o_req = $this->getRequest()) {
 			$va_menu_items = array();
-			
+
 			$va_menu_items['lhm_scanner_import'] = array(
 				'displayName' => 'LHM Depot Scannerdaten',
-				"default" => array(
+				'default' => array(
 					'module' => 'lhmMMS',
-					'controller' => 'ScannerImport', 
+					'controller' => 'ScannerImport',
 					'action' => 'Index'
 				),
 				'requires' => array(
@@ -89,7 +123,7 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 				'displayName' => 'LHM Import Plausibilitätscheck',
 				'default' => array(
 					'module' => 'lhmMMS',
-					'controller' => 'SanityCheck', 
+					'controller' => 'SanityCheck',
 					'action' => 'Index'
 				),
 				'requires' => array(
@@ -150,17 +184,19 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 				)
 			);
 
-			$pa_menu_bar['LHM']['displayName'] = "LHM";
+			$pa_menu_bar['LHM']['displayName'] = 'LHM';
 			$pa_menu_bar['LHM']['navigation'] = $va_menu_items;
 		}
 
 		return $pa_menu_bar;
 	}
 	# -------------------------------------------------------
+
 	/**
 	 * Get plugin user actions
 	 */
-	static public function getRoleActionList() {
+	static public function getRoleActionList()
+	{
 		return array(
 			'can_use_mms_sanity_check' => array(
 				'label' => 'MMS Plausibilitätscheck',
@@ -181,5 +217,5 @@ class lhmMMSPlugin extends BaseApplicationPlugin {
 		);
 	}
 	# -------------------------------------------------------
-	
+
 }

--- a/plugins/lhmMMS/lib/MMSInsuranceFeatures.php
+++ b/plugins/lhmMMS/lib/MMSInsuranceFeatures.php
@@ -90,68 +90,88 @@ class MMSInsuranceFeatures
 	}
 
 
-	/**
-	 * Berechnet bei Änderung eines Objektes oder einer Leihgabe die
-	 * Gesamt-Versicherungssumme für alle betroffenen Leihgaben neu
-	 *
-	 * @param array $pa_params Parameter-Array, das vom Plugin Hook übergeben wird
-	 */
-	public static function calcLoanInsuranceVal(&$pa_params)
+	private static function sumLatestInsuranceValuesForLoan(ca_loans $t_loan): float
 	{
-
-		switch ($pa_params['instance']->tableName()) {
-			// Leihgabe ist neu oder hat sich geändert
-			case 'ca_loans':
-				// berechne Versicherungswert neu
-				self::setInsuranceValForLoan($pa_params['instance']);
-				break;
-			// Ein Objekt ist neu oder hat sich geändert
-			case 'ca_objects':
-				// Hole alle angehängten Leihgaben und berechne Versicherungswerte neu
-				$va_loans = $pa_params['instance']->getRelatedItems('ca_loans');
-				$t_loan = new ca_loans();
-				foreach ($va_loans as $vn_loan_id => $va_loan_info) {
-					if ($t_loan->load($vn_loan_id)) {
-						self::setInsuranceValForLoan($t_loan);
-					}
-				}
-				break;
-			default:
-				return;
-		}
-	}
-
-	/**
-	 * Hilfsfunktion, die für eine gegebene Leihgabe die Versicherungssumme berechnet und setzt
-	 *
-	 * @param ca_loans $t_loan BaseModel Instanz der betroffenen Leihgabe
-	 */
-	private static function setInsuranceValForLoan(&$t_loan)
-	{
-		// Hole alle Objekte
 		$va_objects = $t_loan->getRelatedItems('ca_objects');
+		if (!is_array($va_objects) || !sizeof($va_objects)) {
+			return 0.0;
+		}
+
 		$t_object = new ca_objects();
-		$vn_insurance_sum = 0;
-		foreach ($va_objects as $vn_index => $va_object_info) {
-			// Wie wird summiert? Jedes Objekt kann mehrere Werte haben
-			// Wir nehmen nur den neuesten her. Dieser lässt sich einfach finden, indem man nach PK sortiert
-			$t_object->load($va_object_info['object_id']);
-			$va_values = $t_object->get('ca_objects.insurance_value_current.current_value_eur', ['returnAsArray' => true]);
-			if (!is_array($va_values)) {
+		$sum = 0.0;
+
+		foreach ($va_objects as $va) {
+			if (!$t_object->load($va['object_id'])) {
 				continue;
 			}
 
-			ksort($va_values); // sortiere nach Primärschlüssel der Werte
-			$vs_val = array_pop($va_values); // wir nehmen den neuesten Wert
+			$vals = $t_object->get('ca_objects.insurance_value_current.current_value_eur', ['returnAsArray' => true]);
+			if (!is_array($vals) || !sizeof($vals)) {
+				continue;
+			}
 
-			$vn_insurance_sum += mmsExtractFloatFromCurrencyValue($vs_val);
+			ksort($vals);               //der letzte Wer
+			$last = array_pop($vals);
+			$sum += mmsExtractFloatFromCurrencyValue($last);
 		}
 
-		// editiere den existierenden automatisch gesetzten Wert oder lege einen neuen an
-		$t_loan->replaceAttribute(array('loan_insurance_remark' => mmsGetSettingFromMMSPluginConfig('lhm_mms_loan_insurance_comment'), 'loan_insurance_value_eur' => mmsFloatToCurrencyValue($vn_insurance_sum),), 'loan_insurance');
-
-		$t_loan->update();
+		return $sum;
 	}
 
+	public static function recalcLoanInsuranceOnOpen(&$pa_params)
+	{
+		if (($pa_params['table_name'] ?? null) !== 'ca_loans') {
+			return;
+		}
+
+		/** @var ca_loans $t_loan */
+		$t_loan = $pa_params['instance'];
+		if (!$t_loan || ($t_loan->tableName() !== 'ca_loans')) {
+			return;
+		}
+
+		// Neue Summe der verknüpften Objekte
+		$sumNew = self::sumLatestInsuranceValuesForLoan($t_loan);
+
+		// Der aktuell in der DB gespeicherte Wert
+		$stored = $t_loan->get('ca_loans.loan_insurance.loan_insurance_value_eur', ['returnAsArray' => false]);
+		$sumStored = mmsExtractFloatFromCurrencyValue((string)$stored);
+
+		// Den Differenzwert gerundet vergleichen
+		$sumNewRounded = round($sumNew, 2);
+		$sumStoredRounded = round($sumStored, 2);
+
+		// Nur wenn ein Unterschied besteht → den neuen Wert im Formular setzen und eine Meldung ausgeben!
+		if (abs($sumNewRounded - $sumStoredRounded) > 0.00001) {
+			$t_loan->replaceAttribute(['loan_insurance_remark' => mmsGetSettingFromMMSPluginConfig('lhm_mms_loan_insurance_comment'), 'loan_insurance_value_eur' => mmsFloatToCurrencyValue($sumNewRounded),], 'loan_insurance');
+
+			mmsAddWarningBox('Neue Versicherungssumme wurde automatisch generiert. ' . 'Bitte prüfen – Speichern ist erforderlich.');
+		}
+		// Wenn gleich → nichts tun → keine Meldung.
+	}
+
+	public static function calcLoanInsuranceVal(&$pa_params)
+	{
+
+		$tbl = $pa_params['instance']->tableName();
+
+		if ($tbl === 'ca_loans') {
+			$t_loan = $pa_params['instance'];
+
+			$newSum = self::sumLatestInsuranceValuesForLoan($t_loan);
+
+			$stored = $t_loan->get('ca_loans.loan_insurance.loan_insurance_value_eur', ['returnAsArray' => false]);
+			$storedFloat = mmsExtractFloatFromCurrencyValue($stored);
+
+			if (abs($newSum - $storedFloat) > 0.0001) {
+				// Im Formular eintragen und speichern
+				$t_loan->replaceAttribute(['loan_insurance_remark' => mmsGetSettingFromMMSPluginConfig('lhm_mms_loan_insurance_comment'), 'loan_insurance_value_eur' => mmsFloatToCurrencyValue($newSum),], 'loan_insurance');
+				$t_loan->update();
+
+				mmsAddWarningBox('Es wurde ein Objekt verknüpft oder geändert. Die Versicherungssumme hat sich geändert. Bitte prüfen und erneut speichern.');
+			}
+
+		}
+	}
 
 }

--- a/plugins/lhmMMS/lib/mmsHelpers.php
+++ b/plugins/lhmMMS/lib/mmsHelpers.php
@@ -10,20 +10,28 @@
  * Fügt Warnungs-Box zu aktueller HTTP Antwort hinzu
  * @param string $ps_message Nachricht, die in der Warnungs-Box erscheinen soll
  */
-function mmsAddWarningBox($ps_message) {
+function mmsAddWarningBox($ps_message)
+{
 	global $g_request, $g_response;
 
-	if(is_object($g_response)){
+	if (is_object($g_response)) {
 		/** @var RequestHTTP $g_request */
 		/** @var ResponseHTTP $g_response */
-		if($g_request->getController() != 'ScannerImport') { // keine Warnungs-Boxen beim Scanner import
+		if ($g_request->getController() != 'ScannerImport') { // keine Warnungs-Boxen beim Scanner import
 			$g_response->addContent("
 				<div class='notification-error-box rounded'>
-					<ul class='notification-error-box'>
+				   <ul class='notification-error-box'>
+				   <li class='notification-error-box'>
+				   	<div class='notification-message-container'>
+			       <i class='fa fa-exclamation-triangle' aria-hidden='true' style='font-size: 36px;'></i>
+			       <ul class='notification-error-box'>
 						<li class='notification-error-box'>{$ps_message}</li>
 					</ul>
+				  </div>
+				  </li>
+                   </ul>	
 				</div>
-			",'default');
+			", 'default');
 		}
 	}
 }
@@ -35,9 +43,10 @@ function mmsAddWarningBox($ps_message) {
  * @param string $ps_setting Die Einstellung, die geholt werden soll
  * @return mixed Der Wert für die Einstellung
  */
-function mmsGetSettingFromMMSPluginConfig($ps_setting) {
+function mmsGetSettingFromMMSPluginConfig($ps_setting)
+{
 	// Configuration::load cacht die Objekte, es gibt also keinen Grund, das hier nicht zu machen
-	$o_conf = Configuration::load(__CA_APP_DIR__.'/plugins/lhmMMS/conf/lhmMMS.conf');
+	$o_conf = Configuration::load(__CA_APP_DIR__ . '/plugins/lhmMMS/conf/lhmMMS.conf');
 	return $o_conf->get($ps_setting);
 }
 
@@ -45,48 +54,52 @@ function mmsGetSettingFromMMSPluginConfig($ps_setting) {
  * Holt den aktuell eingeloggten Benutzer. Funktioniert NICHT in CLI Scripten!
  * @return ca_users Der Benutzer
  */
-function mmsGetCurrentUser() {
+function mmsGetCurrentUser()
+{
 	global $g_request;
 
-	if(is_object($g_request)){
+	if (is_object($g_request)) {
 		return $g_request->getUser();
 	} else {
 		return false;
 	}
 }
 
-function mmsGetCurrentUserDisplayName() {
-	if($t_user = mmsGetCurrentUser()) {
+function mmsGetCurrentUserDisplayName()
+{
+	if ($t_user = mmsGetCurrentUser()) {
 		return $t_user->getName();
 	} else {
 		return 'Importer';
 	}
 }
 
-function mmsExtractFloatFromCurrencyValue($ps_value) {
+function mmsExtractFloatFromCurrencyValue($ps_value)
+{
 	global $_locale;
-	
+
 	$va_matches = array();
-	if(preg_match("!^([\d\.\,]+)([^\d]+)$!u",$ps_value,$va_matches)) {
+	if (preg_match('!^([\d\.\,]+)([^\d]+)$!u', $ps_value, $va_matches)) {
 		$vs_decimal = $va_matches[1];
-	} elseif(preg_match("!^([^\d]+)([\d\.\,]+)$!u",$ps_value,$va_matches)) {
+	} elseif (preg_match('!^([^\d]+)([\d\.\,]+)$!u', $ps_value, $va_matches)) {
 		$vs_decimal = $va_matches[2];
 	}
 
 	$o_locale = $_locale ? $_locale : new Zend_Locale('de_DE');
-	
+
 	try {
-		return (float) Zend_Locale_Format::getNumber($vs_decimal, array('locale' => $o_locale, 'precision' => 2));
-	} catch (Zend_Locale_Exception $e){
+		return (float)Zend_Locale_Format::getNumber($vs_decimal, array('locale' => $o_locale, 'precision' => 2));
+	} catch (Zend_Locale_Exception $e) {
 		return 0;
 	}
 }
 
-function mmsFloatToCurrencyValue($pn_value){
+function mmsFloatToCurrencyValue($pn_value)
+{
 	global $_locale;
-	
-	$o_locale = $_locale ? $_locale : new Zend_Locale('de_DE');
- 	$vs_decimal = Zend_Locale_Format::toNumber($pn_value, array('locale' => $o_locale, 'precision' => 2));
 
- 	return $vs_decimal.' EUR';
+	$o_locale = $_locale ? $_locale : new Zend_Locale('de_DE');
+	$vs_decimal = Zend_Locale_Format::toNumber($pn_value, array('locale' => $o_locale, 'precision' => 2));
+
+	return $vs_decimal . ' EUR';
 }


### PR DESCRIPTION
- Added comparison between stored loan_insurance_value_eur and newly calculated sum
- Suppressed automatic warning box on reload when values are identical
- Now warning + unsaved changes appear only if the recalculated sum differs
- Ensures cleaner UX: no false positives after saving and reloading loans
